### PR TITLE
Removing exceptions

### DIFF
--- a/documentation/Build.md
+++ b/documentation/Build.md
@@ -1,6 +1,53 @@
+# webrtc build
+```
+export PATH=/Users/pablito25sp/workspace/depot_tools:$PATH
+gclient sync
+cd src
+nano -w tools_webrtc/ios/build_ios_libs.py
+python tools_webrtc/ios/build_ios_libs.py --extra-gn-args='is_component_build=false rtc_include_tests=false rtc_enable_protobuf=false use_rtti=true use_custom_libcxx=false'
+cd out_ios_libs
+ninja -C arm64_libs/ webrtc
+ninja -C x64_libs/ webrtc
+
+mkdir universal
+lipo -create arm64_libs/obj/libwebrtc.a x64_libs/obj/libwebrtc.a -output universal/libwebrtc.a
+```
+
+# mediasoup-client-ios dependencies build
+```
+cd /Users/pablito25sp/workspace/mediasoup-ios-client/mediasoup-client-ios/dependencies/
+
+cmake . -Bbuild \
+  -DLIBWEBRTC_INCLUDE_PATH=/Users/pablito25sp/workspace/playground/livekit/webrtc-chrome-src/src \
+  -DLIBWEBRTC_BINARY_PATH=/Users/pablito25sp/workspace/mediasoup-ios-client/mediasoup-client-ios/dependencies/webrtc/src/out_ios_libs/universal \
+  -DMEDIASOUP_LOG_TRACE=ON -DMEDIASOUP_LOG_DEV=ON -DCMAKE_CXX_FLAGS="-fvisibility=hidden" \
+  -DLIBSDPTRANSFORM_BUILD_TESTS=OFF -DIOS_SDK=iphone -DIOS_ARCHS="arm64"
+
+make -C build
+
+cmake . -Bbuild_86_64 \
+  -DLIBWEBRTC_INCLUDE_PATH=/Users/pablito25sp/workspace/playground/livekit/webrtc-chrome-src/src \
+  -DLIBWEBRTC_BINARY_PATH=/Users/pablito25sp/workspace/mediasoup-ios-client/mediasoup-client-ios/dependencies/webrtc/src/out_ios_libs/universal \
+  -DMEDIASOUP_LOG_TRACE=ON -DMEDIASOUP_LOG_DEV=ON -DCMAKE_CXX_FLAGS="-fvisibility=hidden" \
+  -DLIBSDPTRANSFORM_BUILD_TESTS=OFF -DIOS_SDK=iphonesimulator -DIOS_ARCHS="x86_64"
+
+make -C build_86_64
+
+lipo -create build/libmediasoupclient/libmediasoupclient.a build_86_64/libmediasoupclient/libmediasoupclient.a -output libmediasoupclient/lib/libmediasoupclient.a
+
+lipo -create build/libmediasoupclient/libsdptransform/libsdptransform.a build_86_64/libmediasoupclient/libsdptransform/libsdptransform.a -output libmediasoupclient/lib/libsdptransform.a
+```
+Once build include the libwebrtc.a, libmediasoup.a, libsdptransform.a in the project
+
 # clean
-```rm -rf build/*```
+```
+rm -rf build/*
+```
 # arm64
-```xcodebuild -project mediasoup-client-ios.xcodeproj -scheme mediasoup-client-ios -configuration Release -arch arm64 only_active_arch=no -sdk "iphoneos" -derivedDataPath build```
+```
+xcodebuild -project mediasoup-client-ios.xcodeproj -scheme mediasoup-client-ios -configuration Release -arch arm64 only_active_arch=no -sdk "iphoneos" -derivedDataPath build
+```
 # x86_64
-```xcodebuild -project mediasoup-client-ios.xcodeproj -scheme mediasoup-client-ios -configuration Release -arch x86_64 only_active_arch=no -sdk "iphonesimulator" -derivedDataPath build```
+```
+xcodebuild -project mediasoup-client-ios.xcodeproj -scheme mediasoup-client-ios -configuration Release -arch x86_64 only_active_arch=no -sdk "iphonesimulator" -derivedDataPath build
+```

--- a/documentation/Build.md
+++ b/documentation/Build.md
@@ -1,0 +1,6 @@
+# clean
+```rm -rf build/*```
+# arm64
+```xcodebuild -project mediasoup-client-ios.xcodeproj -scheme mediasoup-client-ios -configuration Release -arch arm64 only_active_arch=no -sdk "iphoneos" -derivedDataPath build```
+# x86_64
+```xcodebuild -project mediasoup-client-ios.xcodeproj -scheme mediasoup-client-ios -configuration Release -arch x86_64 only_active_arch=no -sdk "iphonesimulator" -derivedDataPath build```

--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -84,6 +84,16 @@ lipo -create build/libmediasoupclient/libsdptransform/libsdptransform.a build_86
 
 Once build include the libwebrtc.a, libmediasoup.a, libsdptransform.a in the project
 
+## clean and build mediasoup-ios-client
+move to the root of the project
+```
+rm -rf build/*
+
+xcodebuild -project mediasoup-client-ios.xcodeproj -scheme mediasoup-client-ios -configuration Release -arch arm64 only_active_arch=no -sdk "iphoneos" -derivedDataPath build
+
+xcodebuild -project mediasoup-client-ios.xcodeproj -scheme mediasoup-client-ios -configuration Release -arch x86_64 only_active_arch=no -sdk "iphonesimulator" -derivedDataPath build
+```
+
 ---
 ## If you pulled WebRTC repo, apply this patch so compilation works
 https://github.com/ethand91/webrtc-mac-src/commit/58c5047b4c5f412dd7dfdf523ea5a5eb3f80d932

--- a/mediasoup-client-ios.xcodeproj/project.pbxproj
+++ b/mediasoup-client-ios.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		2F6EBD0D268279A000E51BFE /* WebRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F6EBD0C268279A000E51BFE /* WebRTC.framework */; };
+		2FD8F19F26AEDBE50057F6DB /* Error.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FD8F19E26AEDBE50057F6DB /* Error.h */; };
 		3519FB1E24872D1200DD3AF5 /* libmediasoupclient.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 35516F352408C0EE00AC60B4 /* libmediasoupclient.a */; };
 		3519FB1F24872D3300DD3AF5 /* libsdptransform.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 35516F332408C0D500AC60B4 /* libsdptransform.a */; };
 		3519FB2024872D5600DD3AF5 /* libwebrtc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 35516F372408C11000AC60B4 /* libwebrtc.a */; };
@@ -59,6 +60,7 @@
 
 /* Begin PBXFileReference section */
 		2F6EBD0C268279A000E51BFE /* WebRTC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebRTC.framework; path = "mediasoup-client-ios/dependencies/webrtc/src/out_ios_libs/universal/WebRTC.framework"; sourceTree = "<group>"; };
+		2FD8F19E26AEDBE50057F6DB /* Error.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Error.h; sourceTree = "<group>"; };
 		2FE22FED26702F6A00E7E6AB /* CoreAudioTypes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudioTypes.framework; path = System/Library/Frameworks/CoreAudioTypes.framework; sourceTree = SDKROOT; };
 		351A83202394A4BA00BA7A13 /* Transport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Transport.h; sourceTree = "<group>"; };
 		351A83212394A68700BA7A13 /* Transport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Transport.mm; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 				351A832D2394B09600BA7A13 /* Producer.h */,
 				351A83392394DC6A00BA7A13 /* SendTransport.h */,
 				351A833A2394DC7300BA7A13 /* RecvTransport.h */,
+				2FD8F19E26AEDBE50057F6DB /* Error.h */,
 			);
 			path = include;
 			sourceTree = "<group>";
@@ -255,6 +258,7 @@
 				351A833C2394DC7900BA7A13 /* RecvTransport.h in Headers */,
 				3570311C2397802C00761AF5 /* LoggerWrapper.h in Headers */,
 				35D762DD238CBA2C0033D7AD /* ConsumerWrapper.h in Headers */,
+				2FD8F19F26AEDBE50057F6DB /* Error.h in Headers */,
 				351A833B2394DC7700BA7A13 /* SendTransport.h in Headers */,
 				3570311A23977E0F00761AF5 /* MediasoupLogger.h in Headers */,
 				351A83282394AF7C00BA7A13 /* MediasoupclientWrapper.h in Headers */,

--- a/mediasoup-client-ios.xcodeproj/project.pbxproj
+++ b/mediasoup-client-ios.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		2F6EBD0D268279A000E51BFE /* WebRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F6EBD0C268279A000E51BFE /* WebRTC.framework */; };
 		2FD8F19F26AEDBE50057F6DB /* Error.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FD8F19E26AEDBE50057F6DB /* Error.h */; };
 		3519FB1E24872D1200DD3AF5 /* libmediasoupclient.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 35516F352408C0EE00AC60B4 /* libmediasoupclient.a */; };
 		3519FB1F24872D3300DD3AF5 /* libsdptransform.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 35516F332408C0D500AC60B4 /* libsdptransform.a */; };
@@ -59,7 +58,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		2F6EBD0C268279A000E51BFE /* WebRTC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebRTC.framework; path = "mediasoup-client-ios/dependencies/webrtc/src/out_ios_libs/universal/WebRTC.framework"; sourceTree = "<group>"; };
 		2FD8F19E26AEDBE50057F6DB /* Error.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Error.h; sourceTree = "<group>"; };
 		2FE22FED26702F6A00E7E6AB /* CoreAudioTypes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudioTypes.framework; path = System/Library/Frameworks/CoreAudioTypes.framework; sourceTree = SDKROOT; };
 		351A83202394A4BA00BA7A13 /* Transport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Transport.h; sourceTree = "<group>"; };
@@ -118,7 +116,6 @@
 				3519FB1E24872D1200DD3AF5 /* libmediasoupclient.a in Frameworks */,
 				3519FB1F24872D3300DD3AF5 /* libsdptransform.a in Frameworks */,
 				3519FB2024872D5600DD3AF5 /* libwebrtc.a in Frameworks */,
-				2F6EBD0D268279A000E51BFE /* WebRTC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -200,7 +197,6 @@
 		35E2E4892385289700E315FD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				2F6EBD0C268279A000E51BFE /* WebRTC.framework */,
 				2FE22FED26702F6A00E7E6AB /* CoreAudioTypes.framework */,
 				35516F372408C11000AC60B4 /* libwebrtc.a */,
 				35516F352408C0EE00AC60B4 /* libmediasoupclient.a */,

--- a/mediasoup-client-ios/include/Consumer.h
+++ b/mediasoup-client-ios/include/Consumer.h
@@ -54,9 +54,9 @@
 
 /*!
     @brief Executed when the transport this consumer belongs to is closed for whatever reason. The consumer itself is also closed
-    @param consumer The consumer instance executing this method
+    @param consumerId The consumer id of the consumer instance executing this method
  */
--(void)onTransportClose:(Consumer *)consumer;
+-(void)onTransportClose:(NSString *)consumerId;
 
 @end
 

--- a/mediasoup-client-ios/include/Error.h
+++ b/mediasoup-client-ios/include/Error.h
@@ -1,0 +1,19 @@
+//
+//  Error.h
+//  mediasoup-client-ios
+//
+//  Created by Pablo San Pietro on 7/26/21.
+//  Copyright © 2021 Denvir Ethan. All rights reserved.
+//
+
+#ifndef Error_h
+#define Error_h
+
+enum {
+  NativeDisposedError = 1,
+  NotLoadedError = 2,
+  LoadError = 3,
+  RuntimeError = 4
+};
+
+#endif /* Error_h */

--- a/mediasoup-client-ios/include/MediasoupDevice.h
+++ b/mediasoup-client-ios/include/MediasoupDevice.h
@@ -14,13 +14,6 @@
 #ifndef MediasoupDevice_h
 #define MediasoupDevice_h
 
-enum {
-  NativeDeviceDisposedError = 1,
-  NotLoadedError = 2,
-  LoadError = 3,
-  RuntimeError = 4
-};
-
 @interface MediasoupDevice : NSObject
 /*! @brief libmediasoupclient native device object */
 @property(nonatomic, strong) NSValue* _nativeDevice;

--- a/mediasoup-client-ios/include/MediasoupDevice.h
+++ b/mediasoup-client-ios/include/MediasoupDevice.h
@@ -16,7 +16,9 @@
 
 enum {
   NativeDeviceDisposedError = 1,
-  NotLoadedError = 1
+  NotLoadedError = 2,
+  LoadError = 3,
+  RuntimeError = 4
 };
 
 @interface MediasoupDevice : NSObject

--- a/mediasoup-client-ios/include/MediasoupDevice.h
+++ b/mediasoup-client-ios/include/MediasoupDevice.h
@@ -14,6 +14,10 @@
 #ifndef MediasoupDevice_h
 #define MediasoupDevice_h
 
+enum {
+  NativeDeviceDisposedError = 1
+};
+
 @interface MediasoupDevice : NSObject
 /*! @brief libmediasoupclient native device object */
 @property(nonatomic, strong) NSValue* _nativeDevice;
@@ -30,7 +34,7 @@
     @discussion This method takes the RTP capabilities of the mediasoup router and works out what media codecs to use etc.
     @param routerRtpCapabilities mediasoup router RTP capabilities
  */
--(void)load:(NSString *)routerRtpCapabilities;
+-(BOOL)load:(NSString *)routerRtpCapabilities error:(NSError **)errPtr;
 /*!
     @brief Checks whether the device has been loaded
     @return Whether the device has been loaded or not
@@ -41,13 +45,13 @@
     @returns Device's RTP capabilities
     @throws The device has not been loaded
  */
--(NSString *)getRtpCapabilities;
+-(NSString *)getRtpCapabilities:(NSError **)errPtr;
 /*!
     @brief Returns the devices sctpCapabilities
     @returns Devices SCTP Capabilities
     @throws The device has not been loaded
  */
--(NSString *)getSctpCapabilities;
+-(NSString *)getSctpCapabilities:(NSError **)errPtr;
 /*!
     @brief Returns whether the device can produce media of the given kind
     @discussion This depends on the media codecs enabled in the mediasoup router and the media capabilities of libwebrtc

--- a/mediasoup-client-ios/include/MediasoupDevice.h
+++ b/mediasoup-client-ios/include/MediasoupDevice.h
@@ -15,7 +15,8 @@
 #define MediasoupDevice_h
 
 enum {
-  NativeDeviceDisposedError = 1
+  NativeDeviceDisposedError = 1,
+  NotLoadedError = 1
 };
 
 @interface MediasoupDevice : NSObject
@@ -68,7 +69,7 @@ enum {
     @param dtlsParameters DTLS parameters of the server side transport
     @return SendTransport
  */
--(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters;
+-(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters error:(NSError **)errPtr;
 /*!
    @brief Creates a new WebRTC transport to <b>send</b> media
    @discussion The transport must be previously created in the mediasoup router
@@ -82,7 +83,7 @@ enum {
    @param appData Custom application data
    @return SendTransport
 */
--(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData;
+-(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData error:(NSError **)errPtr;
 /*!
     @brief Creates a new WebRTC transport to <b>receive</b> media
     @discussion The transport must be previously created in the mediasoup router
@@ -93,7 +94,7 @@ enum {
     @param dtlsParameters DTLS parameters of the server side transport
     @return RecvTransport
  */
--(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters;
+-(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters error:(NSError **)errPtr;
 /*!
    @brief Creates a new WebRTC transport to <b>receive</b> media
    @discussion The transport must be previously created in the mediasoup router
@@ -107,7 +108,7 @@ enum {
    @param appData Custom application data
    @return RecvTransport
 */
--(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData;
+-(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData error:(NSError **)errPtr;
 @end
 
 #endif /* Device_h */

--- a/mediasoup-client-ios/include/Producer.h
+++ b/mediasoup-client-ios/include/Producer.h
@@ -67,9 +67,9 @@
 
 /*!
     @brief Executed when the transport this producer belongs to is closed for whatever reason. The producer itself is also closed
-    @param producer The producer instance executing this method
+    @param producerId The producer id of the producer instance executing this method
  */
--(void)onTransportClose:(Producer *)producer;
+-(void)onTransportClose:(NSString *)producerId;
 
 @end
 

--- a/mediasoup-client-ios/include/RecvTransport.h
+++ b/mediasoup-client-ios/include/RecvTransport.h
@@ -28,7 +28,7 @@
     @param rtpParameters Receive RTP parameters
     @return Consumer
  */
--(Consumer *)consume:(id<ConsumerListener>)listener id:(NSString *)id producerId:(NSString *)producerId kind:(NSString *)kind rtpParameters:(NSString *)rtpParameters;
+-(Consumer *)consume:(id<ConsumerListener>)listener id:(NSString *)id producerId:(NSString *)producerId kind:(NSString *)kind rtpParameters:(NSString *)rtpParameters error:(NSError **)errPtr;
 /*!
    @brief Instructs the transport to receive an audio or video track to the mediasoup router
    @param listener ConsumerListener deletage
@@ -39,7 +39,7 @@
    @param appData Custom application data
    @return Consumer
 */
--(Consumer *)consume:(id<ConsumerListener>)listener id:(NSString *)id producerId:(NSString *)producerId kind:(NSString *)kind rtpParameters:(NSString *)rtpParameters appData:(NSString *)appData;
+-(Consumer *)consume:(id<ConsumerListener>)listener id:(NSString *)id producerId:(NSString *)producerId kind:(NSString *)kind rtpParameters:(NSString *)rtpParameters appData:(NSString *)appData error:(NSError **)errPtr;
 
 @end
 

--- a/mediasoup-client-ios/include/SendTransport.h
+++ b/mediasoup-client-ios/include/SendTransport.h
@@ -47,13 +47,13 @@
 /*!
     @brief Emitted when the transport needs to transmit information about a new producer to the associated server side transport.
     @discussion This even occurs <b>before</b> the produce() method completes
-    @param transport SendTransport instance
+    @param transportId Transport identifier
     @param kind Producer's media kind (video or audio)
     @param rtpParameters Producer's RTP parameters
     @param appData Custom application data (given in the transport.producer() method)
     @param callback Callback that receives the id of the producer
  */
--(void)onProduce:(Transport *)transport kind:(NSString *)kind rtpParameters:(NSString *)rtpParameters appData:(NSString *)appData callback:(void(^)(NSString *))callback;
+-(void)onProduce:(NSString *)transportId kind:(NSString *)kind rtpParameters:(NSString *)rtpParameters appData:(NSString *)appData callback:(void(^)(NSString *))callback;
 @end
 
 #endif /* SendTransport_h */

--- a/mediasoup-client-ios/include/SendTransport.h
+++ b/mediasoup-client-ios/include/SendTransport.h
@@ -28,7 +28,7 @@
     @param codecOptions Per codec specific options
     @return Producer
  */
--(Producer *)produce:(id<ProducerListener>)listener track:(RTCMediaStreamTrack *)track encodings:(NSArray *)encodings codecOptions:(NSString *)codecOptions;
+-(Producer *)produce:(id<ProducerListener>)listener track:(RTCMediaStreamTrack *)track encodings:(NSArray *)encodings codecOptions:(NSString *)codecOptions error:(NSError **)errPtr;
 /*!
    @brief Instructs the transport to send an audio or video track to the mediasoup router
    @param listener ProducerListener delegate
@@ -38,7 +38,7 @@
    @param appData Custom application data
    @return Producer
 */
--(Producer *)produce:(id<ProducerListener>)listener track:(RTCMediaStreamTrack *)track encodings:(NSArray *)encodings codecOptions:(NSString *)codecOptions appData:(NSString *)appData;
+-(Producer *)produce:(id<ProducerListener>)listener track:(RTCMediaStreamTrack *)track encodings:(NSArray *)encodings codecOptions:(NSString *)codecOptions appData:(NSString *)appData error:(NSError **)errPtr;
 
 @end
 

--- a/mediasoup-client-ios/include/Transport.h
+++ b/mediasoup-client-ios/include/Transport.h
@@ -59,16 +59,16 @@
 @required
 /*!
     @brief Called when the transport is about to establish the ICE+DTLS connection and needs to exchange information with the associated server side transport
-    @param transport Transport instance
+    @param transportId Transport identifier
     @param dtlsParameters Local DTLS parameters
  */
--(void)onConnect:(Transport *)transport dtlsParameters:(NSString *)dtlsParameters;
+-(void)onConnect:(NSString *)transportId dtlsParameters:(NSString *)dtlsParameters;
 /*!
     @brief Emitted when the local transport connection state changes
-    @param transport Transport instance
+    @param transportId Transport identifier
     @param connectionState Transport connection state
  */
--(void)onConnectionStateChange:(Transport *)transport connectionState:(NSString *)connectionState;
+-(void)onConnectionStateChange:(NSString *)transportId connectionState:(NSString *)connectionState;
 
 @end
 

--- a/mediasoup-client-ios/include/wrapper/ConsumerWrapper.h
+++ b/mediasoup-client-ios/include/wrapper/ConsumerWrapper.h
@@ -29,41 +29,43 @@
 
 class ConsumerListenerWrapper final : public mediasoupclient::Consumer::Listener {
 private:
-    Protocol<ConsumerListener>* listener_;
-    ::Consumer* consumer_;
+  Protocol<ConsumerListener>* listener_;
+  ::Consumer* consumer_;
 public:
-    ConsumerListenerWrapper(Protocol<ConsumerListener>* listener)
-    : listener_(listener) {}
-    
-    ~ConsumerListenerWrapper() {
-        [consumer_ release];
-        [listener_ release];
+  ConsumerListenerWrapper(Protocol<ConsumerListener>* listener)
+  : listener_(listener) {}
+  
+  ~ConsumerListenerWrapper() {
+    [consumer_ release];
+    [listener_ release];
+  }
+  
+  void OnTransportClose(mediasoupclient::Consumer* nativeConsumer) override {
+    if (this->listener_ != nullptr && nativeConsumer != nullptr) {
+      [this->listener_ onTransportClose:[NSString stringWithUTF8String:nativeConsumer->GetId().c_str()]];
     }
-    
-    void OnTransportClose(mediasoupclient::Consumer* nativeConsumer) override {
-        [this->listener_ onTransportClose:this->consumer_];
-    };
-    
-    void SetConsumer(::Consumer *consumer) {
-        this->consumer_ = consumer;
-    }
+  };
+  
+  void SetConsumer(::Consumer *consumer) {
+    this->consumer_ = consumer;
+  }
 };
 
 class OwnedConsumer {
 public:
-    OwnedConsumer(mediasoupclient::Consumer* consumer, mediasoupclient::Consumer::Listener* listener)
-    : consumer_(consumer), listener_(listener) {}
-    
-    ~OwnedConsumer() {
-        delete listener_;
-        delete consumer_;
-    };
-    
-    mediasoupclient::Consumer *consumer() const { return consumer_; }
-    
+  OwnedConsumer(mediasoupclient::Consumer* consumer, mediasoupclient::Consumer::Listener* listener)
+  : consumer_(consumer), listener_(listener) {}
+  
+  ~OwnedConsumer() {
+    delete listener_;
+    delete consumer_;
+  };
+  
+  mediasoupclient::Consumer *consumer() const { return consumer_; }
+  
 private:
-    mediasoupclient::Consumer* consumer_;
-    mediasoupclient::Consumer::Listener* listener_;
+  mediasoupclient::Consumer* consumer_;
+  mediasoupclient::Consumer::Listener* listener_;
 };
 
 #endif /* ConsumerWrapper_h */

--- a/mediasoup-client-ios/include/wrapper/ProducerWrapper.h
+++ b/mediasoup-client-ios/include/wrapper/ProducerWrapper.h
@@ -31,41 +31,43 @@
 
 class ProducerListenerWrapper final : public mediasoupclient::Producer::Listener {
 private:
-    Protocol<ProducerListener>* listener_;
-    ::Producer* producer_;
+  Protocol<ProducerListener>* listener_;
+  ::Producer* producer_;
 public:
-    ProducerListenerWrapper(Protocol<ProducerListener>* listener)
-    : listener_(listener) {}
-    
-    ~ProducerListenerWrapper() {
-        [producer_ release];
-        [listener_ release];
-    };
-    
-    void OnTransportClose(mediasoupclient::Producer* nativeProducer) override {
-        [this->listener_ onTransportClose:this->producer_];
-    };
-    
-    void SetProducer(::Producer *producer) {
-        this->producer_ = producer;
+  ProducerListenerWrapper(Protocol<ProducerListener>* listener)
+  : listener_(listener) {}
+  
+  ~ProducerListenerWrapper() {
+    [producer_ release];
+    [listener_ release];
+  };
+  
+  void OnTransportClose(mediasoupclient::Producer* nativeProducer) override {
+    if (this->listener_ != nullptr && nativeProducer != nullptr) {
+      [this->listener_ onTransportClose:[NSString stringWithUTF8String:nativeProducer->GetId().c_str()]];
     }
+  };
+  
+  void SetProducer(::Producer *producer) {
+    this->producer_ = producer;
+  }
 };
 
 class OwnedProducer {
 public:
-    OwnedProducer(mediasoupclient::Producer* producer, ProducerListenerWrapper* listener)
-    : producer_(producer), listener_(listener) {}
-    
-    ~OwnedProducer() {
-        delete producer_;
-        delete listener_;
-    };
-    
-    mediasoupclient::Producer* producer() const { return producer_; }
-    
+  OwnedProducer(mediasoupclient::Producer* producer, ProducerListenerWrapper* listener)
+  : producer_(producer), listener_(listener) {}
+  
+  ~OwnedProducer() {
+    delete producer_;
+    delete listener_;
+  };
+  
+  mediasoupclient::Producer* producer() const { return producer_; }
+  
 private:
-    mediasoupclient::Producer* producer_;
-    ProducerListenerWrapper* listener_;
+  mediasoupclient::Producer* producer_;
+  ProducerListenerWrapper* listener_;
 };
 
 #endif /* ProducerWrapper_h */

--- a/mediasoup-client-ios/include/wrapper/TransportWrapper.h
+++ b/mediasoup-client-ios/include/wrapper/TransportWrapper.h
@@ -34,151 +34,124 @@
 
 class SendTransportListenerWrapper : public mediasoupclient::SendTransport::Listener {
 private:
-    Protocol<SendTransportListener>* listener_;
+  Protocol<SendTransportListener>* listener_;
 public:
-    SendTransportListenerWrapper(Protocol<SendTransportListener>* listener)
-    : listener_(listener) {}
-    
-    ~SendTransportListenerWrapper() {
-        [listener_ release];
-    }
-    
-    std::future<void> OnConnect(mediasoupclient::Transport* nativeTransport, const nlohmann::json& dtlsParameters) override {
-        const std::string dtlsParametersString = dtlsParameters.dump();
-        
-        NSValue* transportObject = [NSValue valueWithPointer:nativeTransport];
-        SendTransport* sendTransport = [[[SendTransport alloc] initWithNativeTransport:transportObject] autorelease];
-        
-        [this->listener_ onConnect:sendTransport dtlsParameters:[NSString stringWithUTF8String:dtlsParametersString.c_str()]];
-
-        std::promise<void> promise;
-        promise.set_value();
-
-        [transportObject release];
-
-        return promise.get_future();
-    };
-    
-    void OnConnectionStateChange(mediasoupclient::Transport* nativeTransport, const std::string& connectionState) override {
-        NSValue *transportObject = [NSValue valueWithPointer:nativeTransport];
-        SendTransport *sendTransport = [[[SendTransport alloc] initWithNativeTransport:transportObject] autorelease];
-        
-        [this->listener_ onConnectionStateChange:sendTransport connectionState:[NSString stringWithUTF8String:connectionState.c_str()]];
-
-        [transportObject release];
-    };
-    
-    std::future<std::string> OnProduce(
-                                       mediasoupclient::SendTransport* nativeTransport,
-                                       const std::string& kind,
-                                       nlohmann::json rtpParameters,
-                                       const nlohmann::json& appData) override {
-        
-        const std::string rtpParametersString = rtpParameters.dump();
-        const std::string appDataString = appData.dump();
-        
-        NSValue* transportObject = [NSValue valueWithPointer:nativeTransport];
-        SendTransport* sendTransport = [[[SendTransport alloc] initWithNativeTransport:transportObject] autorelease];
-        
-        __block std::promise<std::string> promise;
-        
-        [this->listener_ onProduce:sendTransport
-            kind: [NSString stringWithUTF8String: kind.c_str()]
-            rtpParameters: [NSString stringWithUTF8String: rtpParametersString.c_str()]
-            appData: [NSString stringWithUTF8String:appDataString.c_str()]
-            callback: ^(NSString* id) {
-                promise.set_value(std::string([id UTF8String]));
-            }
-         ];
-        
-        [transportObject release];
-
-        return promise.get_future();
-    };
+  SendTransportListenerWrapper(Protocol<SendTransportListener>* listener)
+  : listener_(listener) {}
   
-    std::future<std::string> OnProduceData(
-                                           mediasoupclient::SendTransport* nativeTransport,
-                                           const nlohmann::json& sctpStreamParameters,
-                                           const std::string& label,
-                                           const std::string& protocol,
-                                           const nlohmann::json& appData) {
+  ~SendTransportListenerWrapper() {
+    [listener_ release];
+  }
+  
+  std::future<void> OnConnect(mediasoupclient::Transport* nativeTransport, const nlohmann::json& dtlsParameters) override {
+    if (this->listener_ != nullptr && nativeTransport != nullptr) {
+      [this->listener_ onConnect: [NSString stringWithUTF8String:nativeTransport->GetId().c_str()]
+                  dtlsParameters: [NSString stringWithUTF8String:dtlsParameters.dump().c_str()]];
+    }
+
+    std::promise<void> promise;
+    promise.set_value();
+    return promise.get_future();
+  };
+  
+  void OnConnectionStateChange(mediasoupclient::Transport* nativeTransport, const std::string& connectionState) override {
+    if (this->listener_ != nullptr && nativeTransport != nullptr) {
+      [this->listener_ onConnectionStateChange: [NSString stringWithUTF8String:nativeTransport->GetId().c_str()]
+                               connectionState: [NSString stringWithUTF8String:connectionState.c_str()]];
+    }
+  };
+  
+  std::future<std::string> OnProduce(mediasoupclient::SendTransport* nativeTransport,
+                                     const std::string& kind,
+                                     nlohmann::json rtpParameters,
+                                     const nlohmann::json& appData) override {
       
-      __block std::promise<std::string> promise;
-      promise.set_value(std::string("not implemented"));
-      
-      return promise.get_future();
-    };
+    __block std::promise<std::string> promise;
+    
+    [this->listener_ onProduce: [NSString stringWithUTF8String:nativeTransport->GetId().c_str()]
+                          kind: [NSString stringWithUTF8String:kind.c_str()]
+                 rtpParameters: [NSString stringWithUTF8String:rtpParameters.dump().c_str()]
+                       appData: [NSString stringWithUTF8String:appData.dump().c_str()]
+                      callback: ^(NSString* id) { promise.set_value(std::string([id UTF8String])); }];
+    
+    return promise.get_future();
+  };
+
+  std::future<std::string> OnProduceData(mediasoupclient::SendTransport* nativeTransport,
+                                         const nlohmann::json& sctpStreamParameters,
+                                         const std::string& label,
+                                         const std::string& protocol,
+                                         const nlohmann::json& appData) {
+    
+    __block std::promise<std::string> promise;
+    promise.set_value(std::string("not implemented"));
+    return promise.get_future();
+  };
 };
 
 class RecvTransportListenerWrapper final : public mediasoupclient::RecvTransport::Listener {
 private:
-    Protocol<TransportListener>* listener_;
+  Protocol<TransportListener>* listener_;
 public:
-    RecvTransportListenerWrapper(Protocol<TransportListener>* listener)
-    : listener_(listener) {}
-    
-    ~RecvTransportListenerWrapper() {
-        delete this;
+  RecvTransportListenerWrapper(Protocol<TransportListener>* listener)
+  : listener_(listener) {}
+  
+  ~RecvTransportListenerWrapper() {
+    delete this;
+  }
+
+  std::future<void> OnConnect(mediasoupclient::Transport* nativeTransport,
+                              const nlohmann::json& dtlsParameters) override {
+    if (this->listener_ != nullptr && nativeTransport != nullptr) {
+      [this->listener_ onConnect: [NSString stringWithUTF8String:nativeTransport->GetId().c_str()]
+                  dtlsParameters: [NSString stringWithUTF8String:dtlsParameters.dump().c_str()]];
     }
-
-    std::future<void> OnConnect(mediasoupclient::Transport* nativeTransport, const nlohmann::json& dtlsParameters) override {
-        const std::string dtlsParametersString = dtlsParameters.dump();
-        
-        NSValue* transportObject = [NSValue valueWithPointer:nativeTransport];
-        RecvTransport* recvTransport = [[[RecvTransport alloc] initWithNativeTransport:transportObject] autorelease];
-        
-        [this->listener_ onConnect:recvTransport dtlsParameters:[NSString stringWithUTF8String:dtlsParametersString.c_str()]];
-        
-        std::promise<void> promise;
-        promise.set_value();
-
-        [transportObject release];
-        
-        return promise.get_future();
-    };
     
-    void OnConnectionStateChange(mediasoupclient::Transport* nativeTransport, const std::string& connectionState) override {
-        NSValue *transportObject = [NSValue valueWithPointer:nativeTransport];
-        RecvTransport *recvTransport = [[[RecvTransport alloc] initWithNativeTransport:transportObject] autorelease];
-        
-        [this->listener_ onConnectionStateChange:recvTransport connectionState:[NSString stringWithUTF8String:connectionState.c_str()]];
-      
-        [transportObject release];
-    };
+    std::promise<void> promise;
+    promise.set_value();
+    return promise.get_future();
+  };
+  
+  void OnConnectionStateChange(mediasoupclient::Transport* nativeTransport, const std::string& connectionState) override {
+    if (this->listener_ != nullptr && nativeTransport != nullptr) {
+      [this->listener_ onConnectionStateChange: [NSString stringWithUTF8String:nativeTransport->GetId().c_str()]
+                               connectionState: [NSString stringWithUTF8String:connectionState.c_str()]];
+    }
+  };
 };
 
 class OwnedSendTransport {
 public:
-    OwnedSendTransport(mediasoupclient::SendTransport* transport, SendTransportListenerWrapper* listener)
-    : transport_(transport), listener_(listener) {}
-    
-    ~OwnedSendTransport() {
-        delete transport_;
-        delete listener_;
-    }
-    
-    mediasoupclient::SendTransport* transport() const { transport_; }
-    
+  OwnedSendTransport(mediasoupclient::SendTransport* transport, SendTransportListenerWrapper* listener)
+  : transport_(transport), listener_(listener) {}
+  
+  ~OwnedSendTransport() {
+    delete transport_;
+    delete listener_;
+  }
+  
+  mediasoupclient::SendTransport* transport() const { transport_; }
+  
 private:
-    mediasoupclient::SendTransport* transport_;
-    SendTransportListenerWrapper* listener_;
+  mediasoupclient::SendTransport* transport_;
+  SendTransportListenerWrapper* listener_;
 };
 
 class OwnedRecvTransport {
 public:
-    OwnedRecvTransport(mediasoupclient::RecvTransport* transport, RecvTransportListenerWrapper* listener)
-    : transport_(transport), listener_(listener) {}
-    
-    ~OwnedRecvTransport() {
-        delete transport_;
-        delete listener_;
-    }
-    
-    mediasoupclient::RecvTransport* transport() const { return transport_; }
-    
+  OwnedRecvTransport(mediasoupclient::RecvTransport* transport, RecvTransportListenerWrapper* listener)
+  : transport_(transport), listener_(listener) {}
+  
+  ~OwnedRecvTransport() {
+    delete transport_;
+    delete listener_;
+  }
+  
+  mediasoupclient::RecvTransport* transport() const { return transport_; }
+  
 private:
-    mediasoupclient::RecvTransport* transport_;
-    RecvTransportListenerWrapper* listener_;
+  mediasoupclient::RecvTransport* transport_;
+  RecvTransportListenerWrapper* listener_;
 };
 
 #endif /* TransportWrapper_h */

--- a/mediasoup-client-ios/src/C++Wrapper/TransportWrapper.mm
+++ b/mediasoup-client-ios/src/C++Wrapper/TransportWrapper.mm
@@ -110,7 +110,7 @@ using namespace mediasoupclient;
     MSC_TRACE();
     
     [TransportWrapper extractNativeTransport:nativeTransport]->Close();
-//    [nativeTransport release];
+    // [nativeTransport release];
 }
 
 +(NSValue *)nativeGetNativeTransport:(NSValue *)nativeTransport {

--- a/mediasoup-client-ios/src/C++Wrapper/TransportWrapper.mm
+++ b/mediasoup-client-ios/src/C++Wrapper/TransportWrapper.mm
@@ -110,7 +110,7 @@ using namespace mediasoupclient;
     MSC_TRACE();
     
     [TransportWrapper extractNativeTransport:nativeTransport]->Close();
-    [nativeTransport release];
+//    [nativeTransport release];
 }
 
 +(NSValue *)nativeGetNativeTransport:(NSValue *)nativeTransport {

--- a/mediasoup-client-ios/src/Consumer.mm
+++ b/mediasoup-client-ios/src/Consumer.mm
@@ -8,73 +8,120 @@
 
 #import <Foundation/Foundation.h>
 #import <WebRTC/RTCPeerConnectionFactory.h>
-
+#import "Error.h"
 #import "Consumer.h"
 #import "ConsumerWrapper.h"
 
 @implementation Consumer : NSObject
 
+NSString * const ERR_DOMAIN = @"mediasup-client-ios.Consumer";
+
 -(instancetype)initWithNativeConsumer:(NSValue *)nativeConsumer {
-    self = [super init];
-    if (self) {
-        self._nativeConsumer = nativeConsumer;
-        
-        webrtc::MediaStreamTrackInterface *nativeTrack = [ConsumerWrapper getNativeTrack:self._nativeConsumer];
-        rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track(nativeTrack);
-        
-        self._nativeTrack = [RTCMediaStreamTrack mediaTrackForNativeTrack:track factory:[[RTCPeerConnectionFactory alloc] init]];
-    }
-    
-    return self;
+  self = [super init];
+  if (self) {
+    self._nativeConsumer = nativeConsumer;
+    rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track([ConsumerWrapper getNativeTrack:self._nativeConsumer]);
+    self._nativeTrack = [RTCMediaStreamTrack mediaTrackForNativeTrack:track factory:[[RTCPeerConnectionFactory alloc] init]];
+  }
+  return self;
 }
 
 -(NSString *)getId {
+  if ([self consumerExists]) {
     return [ConsumerWrapper getNativeId:self._nativeConsumer];
+  } else {
+    return nil;
+  }
 }
 
 -(NSString *)getProducerId {
+  if ([self consumerExists]) {
     return [ConsumerWrapper getNativeProducerId:self._nativeConsumer];
+  } else {
+    return nil;
+  }
 }
 
 -(bool)isClosed {
+  if ([self consumerExists]) {
     return [ConsumerWrapper isNativeClosed:self._nativeConsumer];
+  } else {
+    return true;
+  }
 }
 
 -(bool)isPaused {
+  if ([self consumerExists]) {
     return [ConsumerWrapper isNativePaused:self._nativeConsumer];
+  } else {
+    return true;
+  }
 }
 
 -(NSString *)getKind {
+  if ([self consumerExists]) {
     return [ConsumerWrapper getNativeKind:self._nativeConsumer];
+  } else {
+    return nil;
+  }
 }
 
 -(RTCMediaStreamTrack *)getTrack {
-    return self._nativeTrack;
+  return self._nativeTrack;
 }
 
 -(NSString *)getRtpParameters {
+  if ([self consumerExists]) {
     return [ConsumerWrapper getNativeRtpParameters:self._nativeConsumer];
+  } else {
+    return nil;
+  }
 }
 
 -(NSString *)getAppData {
+  if ([self consumerExists]) {
     return [ConsumerWrapper getNativeAppData:self._nativeConsumer];
+  } else {
+    return nil;
+  }
 }
 
 -(void)resume {
+  if ([self consumerExists]) {
     [ConsumerWrapper nativeResume:self._nativeConsumer];
+  }
 }
 
 -(void)pause {
+  if ([self consumerExists]) {
     [ConsumerWrapper nativePause:self._nativeConsumer];
+  }
 }
 
 -(NSString *)getStats {
-    return [ConsumerWrapper getNativeStats:self._nativeConsumer];
+  if ([self consumerExists]) {
+    @try {
+      return [ConsumerWrapper getNativeStats:self._nativeConsumer];
+    } @catch (NSException *exception) {
+      return nil;
+    }
+  } else {
+    return nil;
+  }
 }
 
 -(void)close {
+  if ([self consumerExists]) {
     [ConsumerWrapper nativeClose:self._nativeConsumer];
     [self._nativeConsumer release];
+  }
+  if (self._nativeTrack != nil) {
+    [self._nativeTrack release];
+  }
+}
+
+-(bool)consumerExists {
+  return self._nativeConsumer != nil;
 }
 
 @end

--- a/mediasoup-client-ios/src/MediasoupDevice.mm
+++ b/mediasoup-client-ios/src/MediasoupDevice.mm
@@ -11,42 +11,64 @@
 
 @implementation MediasoupDevice : NSObject
 
+NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
+
 -(instancetype)init {
-    self = [super init];
-    if (self) {
-        self._nativeDevice = [DeviceWrapper nativeNewDevice];
-    }
-    
-    return self;
+  self = [super init];
+  if (self) {
+    self._nativeDevice = [DeviceWrapper nativeNewDevice];
+  }
+  return self;
 }
 
--(void)load:(NSString *)routerRtpCapabilities {
-    [self checkDeviceExists];
-    [DeviceWrapper nativeLoad:self._nativeDevice routerRtpCapabilities:routerRtpCapabilities];
+-(BOOL)load:(NSString *)routerRtpCapabilities error:(NSError **)errPtr {
+  if (![self deviceExists]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+    }
+    return NO;
+  }
+
+  [DeviceWrapper nativeLoad:self._nativeDevice routerRtpCapabilities:routerRtpCapabilities];
+  return YES;
 }
 
 -(bool)isLoaded {
-    [self checkDeviceExists];
-    
-    return [DeviceWrapper nativeIsLoaded:self._nativeDevice];
+  if (![self deviceExists]) {
+    return false;
+  }
+  
+  return [DeviceWrapper nativeIsLoaded:self._nativeDevice];
 }
 
--(NSString *)getRtpCapabilities {
-    [self checkDeviceExists];
-    
-    return [DeviceWrapper nativeGetRtpCapabilities:self._nativeDevice];
+-(NSString *)getRtpCapabilities:(NSError **)errPtr {
+  if (![self deviceExists]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+    }
+    return nil;
+  }
+
+  return [DeviceWrapper nativeGetRtpCapabilities:self._nativeDevice];
 }
 
--(NSString *)getSctpCapabilities {
-    [self checkDeviceExists];
-    
-    return [DeviceWrapper nativeGetSctpCapabilities:self._nativeDevice];
+-(NSString *)getSctpCapabilities:(NSError **)errPtr {
+  if (![self deviceExists]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+    }
+    return nil;
+  }
+
+  return [DeviceWrapper nativeGetSctpCapabilities:self._nativeDevice];
 }
 
 -(bool)canProduce:(NSString *)kind {
-    [self checkDeviceExists];
-    
-    return [DeviceWrapper nativeCanProduce:self._nativeDevice kind:kind];
+  if (![self deviceExists]) {
+    return false;
+  }
+  
+  return [DeviceWrapper nativeCanProduce:self._nativeDevice kind:kind];
 }
 
 -(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters {
@@ -79,6 +101,10 @@
         
         throw exception;
     }
+}
+
+-(bool)deviceExists {
+  return self._nativeDevice != nil;
 }
 
 @end

--- a/mediasoup-client-ios/src/MediasoupDevice.mm
+++ b/mediasoup-client-ios/src/MediasoupDevice.mm
@@ -49,6 +49,13 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
     return nil;
   }
 
+  if (![self isLoaded]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NotLoadedError userInfo:nil];
+    }
+    return nil;
+  }
+
   return [DeviceWrapper nativeGetRtpCapabilities:self._nativeDevice];
 }
 
@@ -56,6 +63,13 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
   if (![self deviceExists]) {
     if (errPtr) {
       *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+    }
+    return nil;
+  }
+
+  if (![self isLoaded]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NotLoadedError userInfo:nil];
     }
     return nil;
   }
@@ -71,36 +85,52 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
   return [DeviceWrapper nativeCanProduce:self._nativeDevice kind:kind];
 }
 
--(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters {
-    return [self createSendTransport:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:nil options:nil appData:nil];
-}
-
--(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData {
-    [self checkDeviceExists];
-    
-    NSObject *transport = [DeviceWrapper nativeCreateSendTransport:self._nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
-    
-    return [[SendTransport alloc] initWithNativeTransport:transport];
-}
-
--(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters {
-    return [self createRecvTransport:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:nil options:nil appData:nil];
-}
-
--(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData {
-    [self checkDeviceExists];
-    
-    NSObject *transport = [DeviceWrapper nativeCreateRecvTransport:self._nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
-    
-    return [[RecvTransport alloc] initWithNativeTransport:transport];
-}
-
--(void)checkDeviceExists {
-    if (self._nativeDevice == nil) {
-        NSException* exception = [NSException exceptionWithName:@"IllegalStateException" reason:@"Device has been disposed." userInfo:nil];
-        
-        throw exception;
+-(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters error:(NSError **)errPtr {
+  if (![self deviceExists]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
     }
+    return nil;
+  }
+
+  return [self createSendTransport:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:nil options:nil appData:nil error:nil];
+}
+
+-(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData error:(NSError **)errPtr {
+  if (![self deviceExists]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+    }
+    return nil;
+  }
+
+  NSObject *transport = [DeviceWrapper nativeCreateSendTransport:self._nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
+  
+  return [[SendTransport alloc] initWithNativeTransport:transport];
+}
+
+-(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters error:(NSError **)errPtr {
+  if (![self deviceExists]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+    }
+    return nil;
+  }
+
+  return [self createRecvTransport:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:nil options:nil appData:nil error:nil];
+}
+
+-(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData error:(NSError **)errPtr {
+  if (![self deviceExists]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+    }
+    return nil;
+  }
+
+  NSObject *transport = [DeviceWrapper nativeCreateRecvTransport:self._nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
+  
+  return [[RecvTransport alloc] initWithNativeTransport:transport];
 }
 
 -(bool)deviceExists {

--- a/mediasoup-client-ios/src/MediasoupDevice.mm
+++ b/mediasoup-client-ios/src/MediasoupDevice.mm
@@ -29,8 +29,16 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
     return NO;
   }
 
-  [DeviceWrapper nativeLoad:self._nativeDevice routerRtpCapabilities:routerRtpCapabilities];
-  return YES;
+  @try {
+    [DeviceWrapper nativeLoad:self._nativeDevice routerRtpCapabilities:routerRtpCapabilities];
+    return YES;
+  }
+  @catch (NSException *exception) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:LoadError userInfo:nil];
+    }
+    return NO;
+  }
 }
 
 -(bool)isLoaded {
@@ -56,7 +64,15 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
     return nil;
   }
 
-  return [DeviceWrapper nativeGetRtpCapabilities:self._nativeDevice];
+  @try {
+    return [DeviceWrapper nativeGetRtpCapabilities:self._nativeDevice];
+  }
+  @catch (NSException *exception) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:RuntimeError userInfo:nil];
+    }
+    return nil;
+  }
 }
 
 -(NSString *)getSctpCapabilities:(NSError **)errPtr {
@@ -74,7 +90,15 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
     return nil;
   }
 
-  return [DeviceWrapper nativeGetSctpCapabilities:self._nativeDevice];
+  @try {
+    return [DeviceWrapper nativeGetSctpCapabilities:self._nativeDevice];
+  }
+  @catch (NSException *exception) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:RuntimeError userInfo:nil];
+    }
+    return nil;
+  }
 }
 
 -(bool)canProduce:(NSString *)kind {
@@ -82,18 +106,16 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
     return false;
   }
   
-  return [DeviceWrapper nativeCanProduce:self._nativeDevice kind:kind];
+  @try {
+    return [DeviceWrapper nativeCanProduce:self._nativeDevice kind:kind];
+  }
+  @catch (NSException *exception) {
+    return false;
+  }
 }
 
 -(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters error:(NSError **)errPtr {
-  if (![self deviceExists]) {
-    if (errPtr) {
-      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
-    }
-    return nil;
-  }
-
-  return [self createSendTransport:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:nil options:nil appData:nil error:nil];
+  return [self createSendTransport:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:nil options:nil appData:nil error:errPtr];
 }
 
 -(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData error:(NSError **)errPtr {
@@ -104,20 +126,20 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
     return nil;
   }
 
-  NSObject *transport = [DeviceWrapper nativeCreateSendTransport:self._nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
-  
-  return [[SendTransport alloc] initWithNativeTransport:transport];
-}
-
--(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters error:(NSError **)errPtr {
-  if (![self deviceExists]) {
+  @try {
+    NSObject *transport = [DeviceWrapper nativeCreateSendTransport:self._nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
+    return [[SendTransport alloc] initWithNativeTransport:transport];
+  }
+  @catch (NSException *exception) {
     if (errPtr) {
-      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:RuntimeError userInfo:nil];
     }
     return nil;
   }
+}
 
-  return [self createRecvTransport:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:nil options:nil appData:nil error:nil];
+-(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters error:(NSError **)errPtr {
+  return [self createRecvTransport:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:nil options:nil appData:nil error:errPtr];
 }
 
 -(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData error:(NSError **)errPtr {
@@ -128,9 +150,16 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
     return nil;
   }
 
-  NSObject *transport = [DeviceWrapper nativeCreateRecvTransport:self._nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
-  
-  return [[RecvTransport alloc] initWithNativeTransport:transport];
+  @try {
+    NSObject *transport = [DeviceWrapper nativeCreateRecvTransport:self._nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
+    return [[RecvTransport alloc] initWithNativeTransport:transport];
+  }
+  @catch (NSException *exception) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:RuntimeError userInfo:nil];
+    }
+    return nil;
+  }
 }
 
 -(bool)deviceExists {

--- a/mediasoup-client-ios/src/MediasoupDevice.mm
+++ b/mediasoup-client-ios/src/MediasoupDevice.mm
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Ethan. All rights reserved.
 //
 
+#import "Error.h"
 #import "MediasoupDevice.h"
 #import "DeviceWrapper.h"
 
@@ -24,7 +25,7 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
 -(BOOL)load:(NSString *)routerRtpCapabilities error:(NSError **)errPtr {
   if (![self deviceExists]) {
     if (errPtr) {
-      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDisposedError userInfo:nil];
     }
     return NO;
   }
@@ -52,7 +53,7 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
 -(NSString *)getRtpCapabilities:(NSError **)errPtr {
   if (![self deviceExists]) {
     if (errPtr) {
-      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDisposedError userInfo:nil];
     }
     return nil;
   }
@@ -78,7 +79,7 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
 -(NSString *)getSctpCapabilities:(NSError **)errPtr {
   if (![self deviceExists]) {
     if (errPtr) {
-      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDisposedError userInfo:nil];
     }
     return nil;
   }
@@ -121,7 +122,7 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
 -(SendTransport *)createSendTransport:(id<SendTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData error:(NSError **)errPtr {
   if (![self deviceExists]) {
     if (errPtr) {
-      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDisposedError userInfo:nil];
     }
     return nil;
   }
@@ -145,7 +146,7 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
 -(RecvTransport *)createRecvTransport:(id<RecvTransportListener>)listener id:(NSString *)id iceParameters:(NSString *)iceParameters iceCandidates:(NSString *)iceCandidates dtlsParameters:(NSString *)dtlsParameters sctpParameters:(NSString *)sctpParameters options:(RTCPeerConnectionFactoryOptions *)options appData:(NSString *)appData error:(NSError **)errPtr {
   if (![self deviceExists]) {
     if (errPtr) {
-      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDeviceDisposedError userInfo:nil];
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDisposedError userInfo:nil];
     }
     return nil;
   }

--- a/mediasoup-client-ios/src/MediasoupDevice.mm
+++ b/mediasoup-client-ios/src/MediasoupDevice.mm
@@ -127,6 +127,13 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
     return nil;
   }
 
+  if (![self isLoaded]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NotLoadedError userInfo:nil];
+    }
+    return nil;
+  }
+
   @try {
     NSObject *transport = [DeviceWrapper nativeCreateSendTransport:self._nativeDevice listener:listener id:id iceParameters:iceParameters iceCandidates:iceCandidates dtlsParameters:dtlsParameters sctpParameters:sctpParameters options:options appData:appData];
     return [[SendTransport alloc] initWithNativeTransport:transport];
@@ -147,6 +154,13 @@ NSString * const ERR_DOMAIN = @"mediasup-client-ios.MediasoupDevice";
   if (![self deviceExists]) {
     if (errPtr) {
       *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDisposedError userInfo:nil];
+    }
+    return nil;
+  }
+
+  if (![self isLoaded]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NotLoadedError userInfo:nil];
     }
     return nil;
   }

--- a/mediasoup-client-ios/src/Producer.mm
+++ b/mediasoup-client-ios/src/Producer.mm
@@ -7,86 +7,142 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "Error.h"
 #import "Producer.h"
 #import "ProducerWrapper.h"
 
 @implementation Producer : NSObject
 
+NSString * const ERR_DOMAIN = @"mediasup-client-ios.Producer";
+
 -(instancetype)initWithNativeProducer:(NSValue *)nativeProducer {
-    self = [super init];
-    if (self) {
-        self._nativeProducer = nativeProducer;
-        
-        webrtc::MediaStreamTrackInterface *nativeTrack = [ProducerWrapper getNativeTrack:self._nativeProducer];
-        rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track(nativeTrack);
-        
-        self._nativeTrack = [RTCMediaStreamTrack mediaTrackForNativeTrack:track factory:[[RTCPeerConnectionFactory alloc] init]];
-    }
-    
-    return self;
+  self = [super init];
+  if (self) {
+    self._nativeProducer = nativeProducer;
+    rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track([ProducerWrapper getNativeTrack:self._nativeProducer]);
+    self._nativeTrack = [RTCMediaStreamTrack mediaTrackForNativeTrack:track factory:[[RTCPeerConnectionFactory alloc] init]];
+  }
+  return self;
 }
 
 -(NSString *)getId {
+  if ([self producerExists]) {
     return [ProducerWrapper getNativeId:self._nativeProducer];
+  } else {
+    return nil;
+  }
 }
 
 -(bool)isClosed {
+  if ([self producerExists]) {
     return [ProducerWrapper isNativeClosed:self._nativeProducer];
+  } else {
+    return true;
+  }
 }
 
 -(NSString *)getKind {
+  if ([self producerExists]) {
     return [ProducerWrapper getNativeKind:self._nativeProducer];
+  } else {
+    return nil;
+  }
 }
 
 -(RTCMediaStreamTrack *)getTrack {
-    return self._nativeTrack;
+  return self._nativeTrack;
 }
 
 -(bool)isPaused {
+  if ([self producerExists]) {
     return [ProducerWrapper isNativePaused:self._nativeProducer];
+  } else {
+    return true;
+  }
 }
 
 -(int)getMaxSpatialLayer {
+  if ([self producerExists]) {
     return [ProducerWrapper getNativeMaxSpatialLayer:self._nativeProducer];
+  } else {
+    return 0;
+  }
 }
 
 -(NSString *)getAppData {
+  if ([self producerExists]) {
     return [ProducerWrapper getNativeAppData:self._nativeProducer];
+  } else {
+    return nil;
+  }
 }
 
 -(NSString *)getRtpParameters {
+  if ([self producerExists]) {
     return [ProducerWrapper getNativeRtpParameters:self._nativeProducer];
+  } else {
+    return nil;
+  }
 }
 
 -(void)resume {
+  if ([self producerExists]) {
     [ProducerWrapper nativeResume:self._nativeProducer];
+  }
 }
 
 -(void)pause {
+  if ([self producerExists]) {
     [ProducerWrapper nativePause:self._nativeProducer];
+  }
 }
 
 -(void)setMaxSpatialLayers:(int)layer {
-    [ProducerWrapper setNativeMaxSpatialLayer:self._nativeProducer layer:layer];
+  if ([self producerExists]) {
+    @try {
+      [ProducerWrapper setNativeMaxSpatialLayer:self._nativeProducer layer:layer];
+    } @catch (NSException *exception) {
+      // should change this method and return something?
+    }
+  }
 }
 
 -(void)replaceTrack:(RTCMediaStreamTrack *)track {
-    [ProducerWrapper nativeReplaceTrack:self._nativeProducer track:track.hash];
-    
-    webrtc::MediaStreamTrackInterface *nativeTrack = [ProducerWrapper getNativeTrack:self._nativeProducer];
-    rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> mediaTrack(nativeTrack);
-
-    self._nativeTrack = [RTCMediaStreamTrack mediaTrackForNativeTrack:mediaTrack factory:[[RTCPeerConnectionFactory alloc] init]];
+  if ([self producerExists]) {
+    @try {
+      [ProducerWrapper nativeReplaceTrack:self._nativeProducer track:track.hash];
+      rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> mediaTrack([ProducerWrapper getNativeTrack:self._nativeProducer]);
+      self._nativeTrack = [RTCMediaStreamTrack mediaTrackForNativeTrack:mediaTrack factory:[[RTCPeerConnectionFactory alloc] init]];
+    } @catch (NSException *exception) {
+      // should change this method and return something?
+    }
+  }
 }
 
 -(NSString *)getStats {
-    return [ProducerWrapper getNativeStats:self._nativeProducer];
+  if ([self producerExists]) {
+    @try {
+      return [ProducerWrapper getNativeStats:self._nativeProducer];
+    } @catch (NSException *exception) {
+      return nil;
+    }
+  } else {
+    return nil;
+  }
 }
 
 -(void)close {
+  if ([self producerExists]) {
     [ProducerWrapper nativeClose:self._nativeProducer];
     [self._nativeProducer release];
+  }
+  if (self._nativeTrack != nil) {
     [self._nativeTrack release];
+  }
+}
+
+-(bool)producerExists {
+  return self._nativeProducer != nil;
 }
 
 @end

--- a/mediasoup-client-ios/src/SendTransport.mm
+++ b/mediasoup-client-ios/src/SendTransport.mm
@@ -7,45 +7,54 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "Error.h"
 #import "SendTransport.h"
 #import "TransportWrapper.h"
 #import "Producer.h"
 
 @implementation SendTransport : Transport
 
+NSString * const ERR_DOMAIN = @"mediasup-client-ios.SendTransport";
+
 -(instancetype)initWithNativeTransport:(NSValue *)nativeTransport {
-    self = [super initWithNativeTransport:nativeTransport];
-    if (self) {
-        self._nativeTransport = nativeTransport;
-    }
-    
-    return self;
+  self = [super initWithNativeTransport:nativeTransport];
+  if (self) {
+    self._nativeTransport = nativeTransport;
+  }
+  return self;
 }
 
 -(void)dispose {
-    [self checkTransportExists];
-    
+  if ([self transportExists]) {
     [TransportWrapper nativeFreeTransport:self._nativeTransport];
+  }
 }
 
--(Producer *)produce:(id<ProducerListener>)listener track:(RTCMediaStreamTrack *)track encodings:(NSArray *)encodings codecOptions:(NSString *)codecOptions {
-    return [self produce:listener track:track encodings:encodings codecOptions:codecOptions appData:nil];
+-(Producer *)produce:(id<ProducerListener>)listener track:(RTCMediaStreamTrack *)track encodings:(NSArray *)encodings codecOptions:(NSString *)codecOptions error:(NSError **)errPtr {
+  return [self produce:listener track:track encodings:encodings codecOptions:codecOptions appData:nil error:errPtr];
 }
 
--(Producer *)produce:(id<ProducerListener>)listener track:(RTCMediaStreamTrack *)track encodings:(NSArray *)encodings codecOptions:(NSString *)codecOptions appData:(NSString *)appData {
-    NSUInteger nativeTrack = track.hash;
-    
-    Producer *producer = [TransportWrapper nativeProduce:self._nativeTransport listener:listener track:nativeTrack encodings:encodings codecOptions:codecOptions appData:appData];
-    
-    return producer;
-}
-
--(void)checkTransportExists {
-    if (self._nativeTransport == nil) {
-        NSException* exception = [NSException exceptionWithName:@"IllegalStateException" reason:@"SendTransport has been disposed." userInfo:nil];
-        
-        throw exception;
+-(Producer *)produce:(id<ProducerListener>)listener track:(RTCMediaStreamTrack *)track encodings:(NSArray *)encodings codecOptions:(NSString *)codecOptions appData:(NSString *)appData error:(NSError **)errPtr {
+  if (![self transportExists]) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:NativeDisposedError userInfo:nil];
     }
+    return nil;
+  }
+
+  @try {
+    return [TransportWrapper nativeProduce:self._nativeTransport listener:listener track:track.hash encodings:encodings codecOptions:codecOptions appData:appData];
+  }
+  @catch (NSException *exception) {
+    if (errPtr) {
+      *errPtr = [NSError errorWithDomain:ERR_DOMAIN code:RuntimeError userInfo:nil];
+    }
+    return nil;
+  }
+}
+
+-(bool)transportExists {
+  return self._nativeTransport != nil;
 }
 
 @end

--- a/mediasoup-client-ios/src/Transport.mm
+++ b/mediasoup-client-ios/src/Transport.mm
@@ -88,7 +88,7 @@
 -(void)close {
   if ([self transportExists]) {
     [TransportWrapper nativeClose:self._nativeTransport];
-    [self._nativeTransport release];
+    // [self._nativeTransport release];
   }
 }
 

--- a/mediasoup-client-ios/src/Transport.mm
+++ b/mediasoup-client-ios/src/Transport.mm
@@ -7,51 +7,93 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "Error.h"
 #import "Transport.h"
 #import "TransportWrapper.h"
 
 @implementation Transport : NSObject
 
 -(instancetype)initWithNativeTransport:(NSValue *)nativeTransport {
-    self = [super init];
-    if (self) {
-        self._nativeTransport = nativeTransport;
-    }
-    
-    return self;
+  self = [super init];
+  if (self) {
+    self._nativeTransport = nativeTransport;
+  }
+  return self;
 }
 
 -(NSString *)getId {
+  if ([self transportExists]) {
     return [TransportWrapper getNativeId:self._nativeTransport];
+  } else {
+    return nil;
+  }
 }
 
 -(NSString *)getConnectionState {
+  if ([self transportExists]) {
     return [TransportWrapper getNativeConnectionState:self._nativeTransport];
+  } else {
+    return nil;
+  }
 }
 
 -(NSString *)getAppData {
+  if ([self transportExists]) {
     return [TransportWrapper getNativeAppData:self._nativeTransport];
+  } else {
+    return nil;
+  }
 }
 
 -(NSString *)getStats {
-    return [TransportWrapper getNativeStats:self._nativeTransport];
+  if ([self transportExists]) {
+    @try {
+      return [TransportWrapper getNativeStats:self._nativeTransport];
+    } @catch (NSException *exception) {
+      return nil;
+    }
+  } else {
+    return nil;
+  }
 }
 
 -(bool)isClosed {
+  if ([self transportExists]) {
     return [TransportWrapper isNativeClosed:self._nativeTransport];
+  } else {
+    return true;
+  }
 }
 
 -(void)restartIce:(NSString *)iceParameters {
-    [TransportWrapper nativeRestartIce:self._nativeTransport iceParameters:iceParameters];
+  if ([self transportExists]) {
+    @try {
+      [TransportWrapper nativeRestartIce:self._nativeTransport iceParameters:iceParameters];
+    } @catch (NSException *exception) {
+      // should change this method and return something?
+    }
+  }
 }
 
 -(void)updateIceServers:(NSString *)iceServers {
-    [TransportWrapper nativeUpdateIceServers:self._nativeTransport iceServers:iceServers];
+  if ([self transportExists]) {
+    @try {
+      [TransportWrapper nativeUpdateIceServers:self._nativeTransport iceServers:iceServers];
+    } @catch (NSException *exception) {
+      // should change this method and return something?
+    }
+  }
 }
 
 -(void)close {
+  if ([self transportExists]) {
     [TransportWrapper nativeClose:self._nativeTransport];
     [self._nativeTransport release];
+  }
+}
+
+-(bool)transportExists {
+  return self._nativeTransport != nil;
 }
 
 @end


### PR DESCRIPTION
Exceptions for the following entities are catch now:

- Device ✅
- Transport ✅
- Producer ✅
- Consumer ✅

These had to be taken this into account:

- Objective-C methods can only be translated to Swift’s error handling mechanism if they return Objective-C objects or boolean values
- Swift will invoke the catch block if the Objective-C method returns nil/false, independent of whether an NSError was produced or not
- If an Objective-C method produces an NSError and returns a value the catch blocks is not invoked and the error cannot be retrieved
